### PR TITLE
fix: Fix var.legendPosition proccessing for metric widget

### DIFF
--- a/modules/widget/metric/main.tf
+++ b/modules/widget/metric/main.tf
@@ -4,7 +4,7 @@ terraform {
 
 locals {
   legend = var.legendPosition == null ? null : {
-    legend = { position : var.legendPosition }
+    position : var.legendPosition
   }
 }
 


### PR DESCRIPTION
Fixes #3 

There was incorrect processing of the `var.legendPosition` in the [metric](https://github.com/HENNGE/terraform-aws-cloudwatch-dashboard/blob/3bdba56aa825db3a548f6cc45ce055c6ff5f362b/modules/widget/metric/main.tf#L6) widget.